### PR TITLE
Fix default player

### DIFF
--- a/anime_downloader/config.py
+++ b/anime_downloader/config.py
@@ -9,7 +9,7 @@ APP_DIR = click.get_app_dir(APP_NAME)
 DEFAULT_CONFIG = {
     'dl': {
         'url': False,
-        'player': 'mpv',
+        'player': None,
         'skip_download': False,
         'download_dir': '.',
         'quality': '1080p',
@@ -38,6 +38,9 @@ DEFAULT_CONFIG = {
         'log_level': 'INFO',
         'provider': 'twist.moe',
         'autoplay_next': True
+    },
+    'gui': {
+        'player': 'mpv'
     },
     'siteconfig': {
         'animefrenzy': {

--- a/anime_downloader/gui.py
+++ b/anime_downloader/gui.py
@@ -145,7 +145,7 @@ class Window(QtWidgets.QMainWindow):
 
         self.progressBar.setMaximum(len(animes._episode_urls))
         file = self.generate_m3u8(animes)
-        p = subprocess.Popen([Config["dl"]["player"], file])
+        p = subprocess.Popen([Config["gui"]["player"], file])
         p.wait()
 
     def get_animes(self):


### PR DESCRIPTION
Using dl:s player in config doesn't play along with dl, having a separate config for gui is probably the best choice.